### PR TITLE
Class compatibility tie-break condition is updated to include equality

### DIFF
--- a/src/main/java/domain/Class.java
+++ b/src/main/java/domain/Class.java
@@ -109,7 +109,7 @@ public class Class implements Comparable<domain.Class> {
 
         return (
 
-                e1 < s2 || e2 < s1
+                e1 <= s2 || e2 <= s1
 
         );
 


### PR DESCRIPTION
- (i.e.

int s1 = Parser.ParseMtgTimeStr2IntegerTimeStamp(this.startTime);
int e1 = Parser.ParseMtgTimeStr2IntegerTimeStamp(this.endTime);
int s2 = Parser.ParseMtgTimeStr2IntegerTimeStamp(c2.startTime);
int e2 = Parser.ParseMtgTimeStr2IntegerTimeStamp(c2.endTime);

                return (

                        e1 <= s2 || e2 <= s1

                );
)