### PR TITLE
Feature for Importing & Exporting Schedules is added.

### DIFF
--- a/src/main/java/domain/Class.java
+++ b/src/main/java/domain/Class.java
@@ -2,11 +2,13 @@ package domain;
 
 import DB_Utilities.SelectFromTableInDB;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Class implements Comparable<domain.Class> {
+public class Class implements Comparable<domain.Class>, Serializable {
 
+    private static final long serialVersionUID = 1L;
     private int id;
     private String component;
     private String startTime;

--- a/src/main/java/domain/ClassBundle.java
+++ b/src/main/java/domain/ClassBundle.java
@@ -1,8 +1,10 @@
 package domain;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 
 //import static java.util.Collections.emptyList;
 //import static java.util.Arrays.asList;
@@ -10,8 +12,9 @@ import java.util.List;
 //import static java.util.Optional.of;
 //import static java.util.stream.Collectors.toList;
 
-public class ClassBundle{
+public class ClassBundle implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private String courseSubject;
     private int courseCatalog;
     private static int bundleIdcounter;

--- a/src/main/java/domain/CourseSubject_Catalog_Priority_Tuple.java
+++ b/src/main/java/domain/CourseSubject_Catalog_Priority_Tuple.java
@@ -61,8 +61,8 @@ public class CourseSubject_Catalog_Priority_Tuple {
     public String toString(){
 
         return "Subject: " + subject +
-                ", Catalog: " + catalog +
-                ", Priority: " + priority;
+                ", Catalog: " + catalog;
+               // + ", Priority: " + priority;
     }
 
 }

--- a/src/main/java/domain/InstructorNameRolePair.java
+++ b/src/main/java/domain/InstructorNameRolePair.java
@@ -1,7 +1,10 @@
 package domain;
 
-public class InstructorNameRolePair {
+import java.io.Serializable;
 
+public class InstructorNameRolePair implements Serializable {
+
+    private static final long serialVersionUID = 1L;
     private String instructorName;
     private String instructorRole;
 

--- a/src/main/java/domain/Main.java
+++ b/src/main/java/domain/Main.java
@@ -4,6 +4,8 @@ import DB_Utilities.*;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.io.File;
+import java.io.IOException;
 import java.text.AttributedString;
 import java.util.*;
 import java.util.List;
@@ -720,8 +722,6 @@ public class Main {
             @Override
             public void actionPerformed(ActionEvent e) {
 
-//                List<domain.Class> c1List = classesList.get(0);
-
                 Schedule.scheduleIdcounter = 0;
 
                 List<List<ClassBundle>> classBundlesList = new ArrayList<>();
@@ -734,7 +734,7 @@ public class Main {
                     System.out.println(curBundles);
                     classBundlesList.add(curBundles);
                 }
-
+//
                 List<Schedule> schedules = Schedule.GenerateSchedulesFromClassBundlesList(classBundlesList);
 
 
@@ -763,20 +763,37 @@ public class Main {
                     scheduleListComboBox.addItem(curSchedule);
                 }
 
+                String serializedSchedules_recordName = "";
+                List<Schedule> schedulesIn = new ArrayList<>();
+                try {
+                    for(int i=0;i<lstCourses2BePlannedModel.getSize();i++){
+                        CourseSubject_Catalog_Priority_Tuple curTuple = (CourseSubject_Catalog_Priority_Tuple)lstCourses2BePlannedModel.getElementAt(i);
+                        serializedSchedules_recordName += curTuple.getSubject() + " " + curTuple.getCatalog() + ", ";
+                    }
+
+                    serializedSchedules_recordName = serializedSchedules_recordName.substring(0,serializedSchedules_recordName.length()-2);
+
+                    Serializer.SerializeOut(schedules, serializedSchedules_recordName);//Save the resulting schedules (i.e. export schedules)
+                    Serializer.SerializeIn(serializedSchedules_recordName, schedulesIn);//Restore the saved schedules (i.e. import schedules)
+                } catch (IOException | ClassNotFoundException e1) {
+                    e1.printStackTrace();
+                }
                 int numSchedulesGenerated = schedules.size();
 
-//                System.out.println(schedules);
-
-//                String message2BeDisplayed = schedules.toString();
-                String message2BeDisplayed = Schedule.PrintOutSchedulesToUser(schedules);
-                JTextArea textArea = new JTextArea(25, 75);
-//                textArea.setText(message2BeDisplayed);
-//                textArea.setEditable(false);
-//                textArea.setCaretPosition(0);
+                try {
+                    Schedule.PrintOutSchedulesToUser(schedules, serializedSchedules_recordName);
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
                 JEditorPane ep = new JEditorPane();
                 ep.setContentType("text/html");
+                File file = new File("outputs/ScheduleExports/"+ serializedSchedules_recordName + "/" + serializedSchedules_recordName + ".html");
+                try {
+                    ep.setPage(file.toURI().toURL());
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
                 ep.setEditable(false);
-                ep.setText(message2BeDisplayed);
                 ep.setCaretPosition(0);
                 JScrollPane scrollPane = new JScrollPane(ep);
                 scrollPane.setPreferredSize(new Dimension(1000,500));
@@ -784,8 +801,6 @@ public class Main {
 
                 if (schedules != null )
                     scheduleListToView = schedules;
-
-                System.out.println("hi");
             }
         });
 

--- a/src/main/java/domain/Schedule.java
+++ b/src/main/java/domain/Schedule.java
@@ -4,12 +4,17 @@ import org.sqlite.util.StringUtils;
 
 import java.awt.*;
 import java.awt.font.TextAttribute;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.text.AttributedString;
 import java.util.ArrayList;
 import java.util.List;
+import java.io.Serializable;
 
-public class Schedule {
+public class Schedule implements Serializable{
 
+    private static final long serialVersionUID = 1L;
     private List<ClassBundle> classBundleList;
     public static int scheduleIdcounter;
     private int scheduleId;
@@ -168,15 +173,30 @@ public class Schedule {
 //        Schedule.scheduleIdcounter = scheduleList.size();
     }
 
-    public static String PrintOutSchedulesToUser(List<Schedule> schedules){
+    public static void PrintOutSchedulesToUser(List<Schedule> schedules, String fName) throws IOException {
+        File file = new File("outputs/ScheduleExports/"+fName + "/" + fName + ".html");
+        file.delete();
+        FileWriter fr = new FileWriter(file, true);
+
         String str = "<html>";
         int schdeuleNo=0;
+
+        fr.write(str);
+        str = "";
+
+        int i=0;
         for(Schedule curSchedule:schedules){
+            System.out.println("\n\nWriting HTML:\t" + curSchedule + "\tREMAINING: " + (schedules.size() - ++i) + "\n\n");
+
             str += "<br><br>----------------------------------" +
                             "<font face=\"verdana\" color=\"red\"><b><i>" +
                                     "Plan #" + ++schdeuleNo +
                             "</i></b></font>" +
                     "--------------------------------------<br>";
+
+            fr.write(str);
+            str = "";
+
             List<ClassBundle> classBundles = curSchedule.classBundleList;
             for(ClassBundle curClassBundle:classBundles){
                 String courseSubjectAndCatalog = curClassBundle.getCourseSubject()
@@ -213,6 +233,9 @@ public class Schedule {
                                     numClasses +
                                 "</i></b></font>" +
                             " sessions as follows:<br><br>";
+
+                fr.write(str);
+                str = "";
 
                 int classNo = 0;
                 for(Class curClass:classes){
@@ -266,12 +289,19 @@ public class Schedule {
                                         "</i></b></font>" +
 
                                  "<br><br>";
+
+                    fr.write(str);
+                    str = "";
                 }
 
             }
         }
         str += "</html>";
-        return str;
+
+        fr.write(str);
+        str = "";
+
+        fr.close();
     }
 
     @Override

--- a/src/main/java/domain/Serializer.java
+++ b/src/main/java/domain/Serializer.java
@@ -1,0 +1,51 @@
+package domain;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Serializer {
+
+    public static void SerializeOut(List<Schedule> schedules, String fName) throws IOException {
+
+        (new File("outputs/ScheduleExports/"+fName)).mkdirs();
+        File file2SerializeTo = new File("outputs/ScheduleExports/"+fName + "/" + fName + ".json");
+        file2SerializeTo.createNewFile();
+        FileOutputStream f = new FileOutputStream(file2SerializeTo);
+        ObjectOutputStream o = new ObjectOutputStream(f);
+
+        System.out.println("\n-------------SERIALIZE OUT ------------");
+
+        // Write objects to file
+        int i=0;
+        for(Schedule currSchedule:schedules){
+            System.out.println("\n\nOUT:\t" + ++i + " in " + schedules.size() + "\tREMAINING: " + (schedules.size() - i) + "\n\n");
+            o.writeObject(currSchedule);
+        }
+
+        o.close();
+        f.close();
+    }
+
+    public static void SerializeIn(String fName, List<Schedule> schedulesIn) throws IOException, ClassNotFoundException {
+        FileInputStream fi = new FileInputStream(new File("outputs/ScheduleExports/"+fName + "/" + fName + ".json"));
+        ObjectInputStream oi = new ObjectInputStream(fi);
+
+        System.out.println("\n-------------SERIALIZE IN ------------");
+
+        while(fi.available() > 0){
+            Object obj =  oi.readObject();
+            if(obj instanceof Schedule){
+                Schedule curSchedule = (Schedule) obj;
+                schedulesIn.add(curSchedule);
+//                System.out.println("\n"+curSchedule);
+//                System.out.println(curSchedule.getClassBundleList());
+                System.out.println("\n\nIN:\t" + curSchedule + "\tREMAINING: " + fi.available() + "\n\n");
+            }
+        }
+        oi.close();
+        fi.close();
+
+    }
+
+}


### PR DESCRIPTION
- Required java classes are made serializable.
- Serializer class is created to export and import
the generated schedule lists
- Priority is made invisible to the user.
- Main has been altered to accommodate the changes regarding
serializability of Schedules
- JEditor pane now reveals the created .html file instead of a
concatenated string.
- An .html and .json file is built in a special directory reserved for
the current list of generated schedules.
- Created .json files can be used to import their respective list of schedules
that have been generated in previous runs.
- .html and .json files are too large to upload to remote thereby are not included.

(TODO:

- Add an import and export buttons so as to separate the functionality of
exporting and importing from Generate Schedules Button)